### PR TITLE
🔧 Fixed cd version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - clouddrift=0.35.0
+  - clouddrift=0.35
   - notebook
   - numpy
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - clouddrift
+  - clouddrift=0.35.0
   - notebook
   - numpy
   - xarray


### PR DESCRIPTION
This is so that when a binder instance is instantiated it utilizes the fixed CD version vs what it might have cached or some other scenario causing it to utilize an old/unexpected version of clouddrift.